### PR TITLE
Set proper stable download URLs

### DIFF
--- a/.github/workflows/update-formulae.yml
+++ b/.github/workflows/update-formulae.yml
@@ -29,7 +29,14 @@ jobs:
 
       - name: Update formulae
         id: update-formulae
-        run: echo "::set-output name=changes::$(Scripts/update-formulae | sed -r 's/^/- /')"
+        run: |
+          output=$(Scripts/update-formulae | sed -r 's/^/- /')
+
+          output="${output//'%'/'%25'}"
+          output="${output//$'\n'/'%0A'}"
+          output="${output//$'\r'/'%0D'}"
+
+          echo "::set-output name=changes::$output"
 
       - name: Create or update pull-request
         id: create-pull-request-action

--- a/.github/workflows/update-formulae.yml
+++ b/.github/workflows/update-formulae.yml
@@ -21,7 +21,13 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      # Check out the full repository history in order to determine the correct
+      # latest commit hashes for files versioned in this repository. By default
+      # the checkout action will only fetch the latest commit:
+      # https://github.com/actions/checkout/tree/v2#Fetch-all-history-for-all-tags-and-branches
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v2
         with:

--- a/Formula/bup.rb
+++ b/Formula/bup.rb
@@ -4,9 +4,9 @@ class Bup < Formula
   desc "Interactively upgrade installed brew formulae and casks"
   homepage "https://github.com/pmeinhardt/homebrew-tools"
   head "https://github.com/pmeinhardt/homebrew-tools.git", branch: "main"
-  url "https://github.com/pmeinhardt/homebrew-tools/archive/9e447e547ae8a54b7886de62b99d32e79766af67.tar.gz"
-  sha256 "284b442a9b3946299b3ee6c62a3038631b2e920d6002d37792e48c97cc87d62c"
-  version "0.2.0"
+  url "https://github.com/pmeinhardt/homebrew-tools/archive/4633fa185816d26bc1a4b585cf64a1904008eb92.tar.gz"
+  sha256 "13e303a96aa628f43d54307747289f699cdedad18f5cc2da547f7b92b9372e5d"
+  version "0.3.0"
 
   bottle :unneeded
 

--- a/Formula/tm.rb
+++ b/Formula/tm.rb
@@ -4,9 +4,9 @@ class Tm < Formula
   desc "Start a new tmux session in a specific directory"
   homepage "https://github.com/pmeinhardt/homebrew-tools"
   head "https://github.com/pmeinhardt/homebrew-tools.git", branch: "main"
-  url "https://github.com/pmeinhardt/homebrew-tools/archive/9e447e547ae8a54b7886de62b99d32e79766af67.tar.gz"
-  sha256 "284b442a9b3946299b3ee6c62a3038631b2e920d6002d37792e48c97cc87d62c"
-  version "0.2.0"
+  url "https://github.com/pmeinhardt/homebrew-tools/archive/2833a733c9e02171d8d7c5168ecafdef5eafcffb.tar.gz"
+  sha256 "0fe3dfe39baf6572ad13546d188ee6e086a4b1b9cf365eb5ef65fecc32912d0b"
+  version "0.3.0"
 
   bottle :unneeded
 


### PR DESCRIPTION
For some reason the GitHub workflow automation seems to be using the
overall HEAD revision instead of the most recent commit for local
commands.

Investigating… 🕵️ 