### PR TITLE
Only check for updates once per day

### DIFF
--- a/.github/workflows/update-formulae.yml
+++ b/.github/workflows/update-formulae.yml
@@ -3,9 +3,9 @@
 name: Update formulae
 
 on:
-  # Trigger every hour to check formulae referencing other repositories
+  # Trigger once per day to check formulae referencing other repositories
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 6 * * *"
 
   # Trigger on command source file changes
   push:


### PR DESCRIPTION
This is frequent enough - no need to waste resources.
Plus, there is always the option to trigger the workflow manually.