### PR TITLE
Add `bun` to interactively remove homebrew leaves

### DIFF
--- a/Bin/bun
+++ b/Bin/bun
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Interactively uninstall brew formulae and casks that are not depended on.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+brew leaves \
+  | fzf --multi \
+  | xargs brew uninstall


### PR DESCRIPTION
I like to occasionally go through tools I have installed with Homebrew, checking which ones I am really using and removing those I don't use. *Leaves* are all "formulae that are not dependencies of another installed formula" (see `brew help leaves`). The `bun` command-line tool lets you interactively select leaves to uninstall (via `fzf`). 🧽🧼🪣✨ 