### PR TITLE
Add `ign` command to fetch .gitignore templates

### DIFF
--- a/Bin/ign
+++ b/Bin/ign
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Interactively get `.gitignore` templates from GitHub.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+get () {
+  gh api --header "Accept: application/vnd.github+json" --jq "$2"  "$1"
+}
+
+name=$(get "/gitignore/templates" ".[]" | fzf)
+
+if [ -z "$name" ]; then
+  exit 1
+fi
+
+get "/gitignore/templates/$name" ".source"

--- a/Formula/ign.rb
+++ b/Formula/ign.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Ign < Formula
+  desc "Get .gitignore templates from GitHub"
+  homepage "https://github.com/pmeinhardt/homebrew-tools"
+  head "https://github.com/pmeinhardt/homebrew-tools.git", branch: "main"
+  url ""
+  sha256 ""
+  version "0.1.0"
+
+  depends_on "fzf"
+  depends_on "gh"
+
+  def install
+    bin.install "Bin/ign"
+  end
+end


### PR DESCRIPTION
The command uses the `gh` command-line interface to fetch `.gitignore`
file templates, allowing the user to select from a list of available
templates using `fzf`.
